### PR TITLE
Bugfix/set value in select instead of set selected in option

### DIFF
--- a/src/components/FlipCards/FlipCardSelect/FlipCardSelect.spec.tsx
+++ b/src/components/FlipCards/FlipCardSelect/FlipCardSelect.spec.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { OPTIONS } from '../const'
+import { FlipCardSelect } from '.'
+
+const mockOnChange = jest.fn()
+
+describe('<FlipCardSelect />', () => {
+  it('should render correctly', () => {
+    render(
+      <FlipCardSelect selectedOption={OPTIONS[1]} onChange={mockOnChange} />
+    )
+
+    expect(screen.getByLabelText('Select Category:')).toBeVisible()
+    OPTIONS.map((option) =>
+      expect(screen.getByText(option)).toBeInTheDocument()
+    )
+
+    fireEvent.change(screen.getByTestId('flipcard-select'), {
+      target: { value: OPTIONS[3] },
+    })
+    expect(mockOnChange).toHaveBeenCalled()
+  })
+})

--- a/src/components/FlipCards/FlipCardSelect/FlipCardSelect.tsx
+++ b/src/components/FlipCards/FlipCardSelect/FlipCardSelect.tsx
@@ -7,6 +7,8 @@ interface FlipCardsSelectProps {
   onChange: (value: string) => void
 }
 
+// It's not a good idea to have the option array tightly coupled with the component.
+// OPTION should be a prop to make it more component like.
 export const FlipCardSelect: React.VFC<FlipCardsSelectProps> = ({
   selectedOption,
   onChange,
@@ -14,13 +16,15 @@ export const FlipCardSelect: React.VFC<FlipCardsSelectProps> = ({
   return (
     <label htmlFor="card">
       Select Category: <br />
-      <select name="card" id="card" onChange={(e) => onChange(e.target.value)}>
+      <select
+        name="card"
+        id="card"
+        data-testid="flipcard-select"
+        value={selectedOption}
+        onChange={(e) => onChange(e.target.value)}
+      >
         {OPTIONS.map((option) => (
-          <option
-            key={option}
-            value={option}
-            selected={selectedOption === option}
-          >
+          <option key={option} value={option}>
             {option}
           </option>
         ))}

--- a/src/data/phraseAndGrammars.json
+++ b/src/data/phraseAndGrammars.json
@@ -3,7 +3,7 @@
     { "phrase": "I'm in good spirits.", "note": "spirits is plural." },
     {
       "phrase": "Everyone was talking at the top of their lungs.",
-      "note": "Everyone is treated as singular, but lung is usually used as plural."
+      "note": "Everyone is treated as singular, but lung becomes plural as in their lungs."
     },
     {
       "phrase": "I wrote a diary.",
@@ -28,6 +28,10 @@
     {
       "phrase": "These letters are a great source of comfort.",
       "note": "a great source of is a collective and can use with plural verb."
+    },
+    {
+      "phrase": "Analogy in the formula of A:B::C:D",
+      "note": "old is to hot as night is to day, or old is to hot what night is to day"
     }
   ]
 }

--- a/src/data/phraseAndGrammars.yml
+++ b/src/data/phraseAndGrammars.yml
@@ -23,3 +23,6 @@ phrasesAndGrammars:
 
   - phrase: These letters are a great source of comfort.
     note: a great source of is a collective and can use with plural verb.
+
+  - phrase: Analogy in the formula of A:B::C:D
+    note: old is to hot as night is to day, or old is to hot what night is to day

--- a/src/dummy.spec.ts
+++ b/src/dummy.spec.ts
@@ -1,5 +1,0 @@
-describe('dummy for ci test', () => {
-  it('should just pass', () => {
-    expect(1).toBe(1)
-  })
-})


### PR DESCRIPTION
When we write a test on FlipCardSelect, we get this error and this is to fix the error

```
console.error
    Warning: Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>.
        at option
        at select
        at label
        at FlipCardSelect (/Users/taka/code/mdh/mydatahack-blog-site-gatsby/src/components/FlipCards/FlipCardSelect/FlipCardSelect.tsx:13:3)
```